### PR TITLE
Bug fix to handle api throttling n rescheduling on 429 failures

### DIFF
--- a/cdk/lib/bitbucket-metrics-register-function.ts
+++ b/cdk/lib/bitbucket-metrics-register-function.ts
@@ -17,6 +17,7 @@ const SCM_SECRETS_MANAGER_NAME = 'BitbucketScmSecret';
 export interface CronFunctionProps extends ExtendedNodejsFunctionProps {
   readonly cronExpression: string;
   readonly apiGatewayUrl: string;
+  readonly repositoryTrackerTableName: string;
 }
 export class BitbucketMetricsRegisterFunction extends ExtendedNodejsFunction {
   constructor(scope: Construct, id: string, props: CronFunctionProps) {
@@ -37,6 +38,7 @@ export class BitbucketMetricsRegisterFunction extends ExtendedNodejsFunction {
       timeout: Duration.minutes(15),
       environment: {
         SCM_SECRETS_MANAGER_NAME: SCM_SECRETS_MANAGER_NAME,
+        REPOSITORY_TRACKER_TABLE_NAME: props.repositoryTrackerTableName,
       },
       deploymentOptions: {
         createDeployment: false,
@@ -50,6 +52,13 @@ export class BitbucketMetricsRegisterFunction extends ExtendedNodejsFunction {
           'secretsmanager:DescribeSecret',
           'secretsmanager:ListSecrets',
         ],
+        resources: ['*'],
+      })
+    );
+
+    this.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['events:PutRule', 'events:PutTargets'],
         resources: ['*'],
       })
     );

--- a/cdk/lib/bitbucket-metrics-register-function.ts
+++ b/cdk/lib/bitbucket-metrics-register-function.ts
@@ -62,6 +62,7 @@ export class BitbucketMetricsRegisterFunction extends ExtendedNodejsFunction {
         resources: ['*'],
       })
     );
+
     process.env.SCM_SECRET_MANAGER_NAME = SCM_SECRETS_MANAGER_NAME;
 
     const rule = new Rule(this.stack, 'BitbucketMetricsRegisterRule', {

--- a/cdk/lib/bitbucket-metrics.ts
+++ b/cdk/lib/bitbucket-metrics.ts
@@ -4,6 +4,7 @@ import {Stack, Stage} from 'aws-cdk-lib';
 import {MetricsPublisherFunction} from './metrics-publisher-function';
 import {BitbucketMetricsRegisterFunction} from './bitbucket-metrics-register-function';
 import {AttributeType, BillingMode, Table} from 'aws-cdk-lib/aws-dynamodb';
+import {ServicePrincipal} from 'aws-cdk-lib/aws-iam';
 
 export class BitbucketMetrics extends Construct {
   constructor(scope: Construct, id: string) {
@@ -34,6 +35,10 @@ export class BitbucketMetrics extends Construct {
         apiGatewayUrl: httpApi.url!,
         repositoryTrackerTableName: repositoryTracker.tableName,
       }
+    );
+
+    metricsRegisterFunction.grantInvoke(
+      new ServicePrincipal('events.amazonaws.com')
     );
 
     // Grant the Lambda function read/write permissions to the table

--- a/handlers/package.json
+++ b/handlers/package.json
@@ -23,7 +23,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.515.0",
+    "@aws-sdk/client-dynamodb": "^3.556.0",
+    "@aws-sdk/client-eventbridge": "^3.556.0",
     "@aws-sdk/client-secrets-manager": "^3.554.0",
+    "@aws-sdk/lib-dynamodb": "^3.556.0",
     "axios": "^1.6.8",
     "gts": "^5.2.0",
     "pino": "^8.20.0"

--- a/handlers/pnpm-lock.yaml
+++ b/handlers/pnpm-lock.yaml
@@ -8,9 +8,18 @@ dependencies:
   '@aws-sdk/client-cloudwatch':
     specifier: ^3.515.0
     version: 3.515.0
+  '@aws-sdk/client-dynamodb':
+    specifier: ^3.556.0
+    version: 3.556.0
+  '@aws-sdk/client-eventbridge':
+    specifier: ^3.556.0
+    version: 3.556.0
   '@aws-sdk/client-secrets-manager':
     specifier: ^3.554.0
     version: 3.554.0
+  '@aws-sdk/lib-dynamodb':
+    specifier: ^3.556.0
+    version: 3.556.0(@aws-sdk/client-dynamodb@3.556.0)
   axios:
     specifier: ^1.6.8
     version: 1.6.8
@@ -154,6 +163,105 @@ packages:
       '@smithy/util-utf8': 2.1.1
       '@smithy/util-waiter': 2.1.1
       fast-xml-parser: 4.2.5
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-dynamodb@3.556.0:
+    resolution: {integrity: sha512-Msb/LxTbboX/v5HlR5zcMJ9JI61X83yI6pqsL85CcFrEuzAi+QqSmt84sT9sYU263RKkmo8Py4WazM7uIGs+mw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-endpoint-discovery': 3.535.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
+      tslib: 2.6.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-eventbridge@3.556.0:
+    resolution: {integrity: sha512-Rx3NaRpsMcUdNIOerb8yrmeMKkLOEuK80TYtr/uBWnCUgnwfl69yf7Z5unwvO/7ZswGy7HCN4L/JOtQAWWTQpw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-signing': 3.556.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/signature-v4-multi-region': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -308,6 +416,56 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-sso-oidc@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-AXKd2TB6nNrksu+OfmHl8uI07PdgzOo4o8AxoRO8SHlwoMAGvcT9optDGVSYoVfgOKTymCoE7h8/UoUfPc11wQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': ^3.556.0
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/client-sso@3.515.0:
     resolution: {integrity: sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==}
     engines: {node: '>=14.0.0'}
@@ -361,6 +519,52 @@ packages:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/core': 3.554.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso@3.556.0:
+    resolution: {integrity: sha512-unXdWS7uvHqCcOyC1de+Fr8m3F2vMg2m24GPea0bg7rVGTYmiyn9mhUX11VCt+ozydrw+F50FQwL6OqoqPocmw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/core': 3.556.0
       '@aws-sdk/middleware-host-header': 3.535.0
       '@aws-sdk/middleware-logger': 3.535.0
       '@aws-sdk/middleware-recursion-detection': 3.535.0
@@ -499,6 +703,55 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/client-sts@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-TsK3js7Suh9xEmC886aY+bv0KdLLYtzrcmVt6sJ/W6EnDXYQhBuKYFhp03NrN2+vSvMGpqJwR62DyfKe1G0QzQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': ^3.556.0
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
   /@aws-sdk/core@3.513.0:
     resolution: {integrity: sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==}
     engines: {node: '>=14.0.0'}
@@ -518,6 +771,19 @@ packages:
       '@smithy/core': 1.4.2
       '@smithy/protocol-http': 3.3.0
       '@smithy/signature-v4': 2.2.1
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      fast-xml-parser: 4.2.5
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/core@3.556.0:
+    resolution: {integrity: sha512-vJaSaHw2kPQlo11j/Rzuz0gk1tEaKdz+2ser0f0qZ5vwFlANjt08m/frU17ctnVKC1s58bxpctO/1P894fHLrA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/core': 1.4.2
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       fast-xml-parser: 4.2.5
@@ -614,6 +880,26 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/credential-provider-ini@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-0Nz4ErOlXhe3muxWYMbPwRMgfKmVbBp36BAE2uv/z5wTbfdBkcgUwaflEvlKCLUTdHzuZsQk+BFS/gVyaUeOuA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-env': 3.535.0
+      '@aws-sdk/credential-provider-process': 3.535.0
+      '@aws-sdk/credential-provider-sso': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-web-identity': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
   /@aws-sdk/credential-provider-node@3.515.0:
     resolution: {integrity: sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==}
     engines: {node: '>=14.0.0'}
@@ -644,6 +930,26 @@ packages:
       '@aws-sdk/credential-provider-process': 3.535.0
       '@aws-sdk/credential-provider-sso': 3.554.0(@aws-sdk/credential-provider-node@3.554.0)
       '@aws-sdk/credential-provider-web-identity': 3.554.0(@aws-sdk/credential-provider-node@3.554.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.556.0:
+    resolution: {integrity: sha512-s1xVtKjyGc60O8qcNIzS1X3H+pWEwEfZ7TgNznVDNyuXvLrlNWiAcigPWGl2aAkc8tGcsSG0Qpyw2KYC939LFg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.535.0
+      '@aws-sdk/credential-provider-http': 3.552.0
+      '@aws-sdk/credential-provider-ini': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-process': 3.535.0
+      '@aws-sdk/credential-provider-sso': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-web-identity': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
       '@aws-sdk/types': 3.535.0
       '@smithy/credential-provider-imds': 2.3.0
       '@smithy/property-provider': 2.2.0
@@ -708,6 +1014,22 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/credential-provider-sso@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-ETuBgcnpfxqadEAqhQFWpKoV1C/NAgvs5CbBc5EJbelJ8f4prTdErIHjrRtVT8c02MXj92QwczsiNYd5IoOqyw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.556.0
+      '@aws-sdk/token-providers': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
   /@aws-sdk/credential-provider-web-identity@3.515.0(@aws-sdk/credential-provider-node@3.515.0):
     resolution: {integrity: sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==}
     engines: {node: '>=14.0.0'}
@@ -734,6 +1056,53 @@ packages:
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-R/YAL8Uh8i+dzVjzMnbcWLIGeeRi2mioHVGnVF+minmaIkCiQMZg2HPrdlKm49El+RljT28Nl5YHRuiqzEIwMA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/endpoint-cache@3.535.0:
+    resolution: {integrity: sha512-sPG2l00iVuporK9AmPWq4UBcJURs2RN+vKA8QLRQANmQS3WFHWHamvGltxCjK79izkeqri882V4XlFpZfWhemA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/lib-dynamodb@3.556.0(@aws-sdk/client-dynamodb@3.556.0):
+    resolution: {integrity: sha512-0CsNQyw7z5Fe4bj0oHnrZgz5grVLQI8OuMWUGxVgTeIL6a6kusWR4Ky7+RveAoiLCAYh3FIVvlqAiD4hJdIizQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.0.0
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.556.0
+      '@aws-sdk/util-dynamodb': 3.556.0(@aws-sdk/client-dynamodb@3.556.0)
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/middleware-endpoint-discovery@3.535.0:
+    resolution: {integrity: sha512-+EsqJB5A15RoTf0HxUdknF3hp+2WDg0HWc+QERUctzzYXy9l5LIQjmhQ96cWDyFttKmHE+4h6fjMZjJEeWOeYQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
     dev: false
 
   /@aws-sdk/middleware-host-header@3.515.0:
@@ -794,6 +1163,34 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@aws-sdk/middleware-sdk-s3@3.556.0:
+    resolution: {integrity: sha512-4W/dnxqj1B6/uS/5Z+3UHaqDDGjNPgEVlqf5d3ToOFZ31ZfpANwhcCmyX39JklC4aolCEi9renQ5wHnTCC8K8g==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-arn-parser': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/middleware-signing@3.556.0:
+    resolution: {integrity: sha512-kWrPmU8qd3gI5qzpuW9LtWFaH80cOz1ZJDavXx6PRpYZJ5JaKdUHghwfDlVTzzFYAeJmVsWIkPcLT5d5mY5ZTQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-middleware': 2.2.0
+      tslib: 2.6.2
+    dev: false
+
   /@aws-sdk/middleware-user-agent@3.515.0:
     resolution: {integrity: sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==}
     engines: {node: '>=14.0.0'}
@@ -840,6 +1237,18 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@aws-sdk/signature-v4-multi-region@3.556.0:
+    resolution: {integrity: sha512-bWDSK0ggK7QzAOmPZGv29UAIZocL1MNY7XyOvm3P3P1U3tFMoIBilQQBLabXyHoZ9J3Ik0Vv4n95htUhRQ35ow==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
   /@aws-sdk/token-providers@3.515.0(@aws-sdk/credential-provider-node@3.515.0):
     resolution: {integrity: sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==}
     engines: {node: '>=14.0.0'}
@@ -870,6 +1279,21 @@ packages:
       - aws-crt
     dev: false
 
+  /@aws-sdk/token-providers@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-tvIiugNF0/+2wfuImMrpKjXMx4nCnFWQjQvouObny+wrif/PGqqQYrybwxPJDvzbd965bu1I+QuSv85/ug7xsg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso-oidc': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
   /@aws-sdk/types@3.515.0:
     resolution: {integrity: sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==}
     engines: {node: '>=14.0.0'}
@@ -883,6 +1307,23 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/util-arn-parser@3.535.0:
+    resolution: {integrity: sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/util-dynamodb@3.556.0(@aws-sdk/client-dynamodb@3.556.0):
+    resolution: {integrity: sha512-SF7bEPt8uCiklHkCvDQfGmAl6qADDd/sHHjcWS0zGYPesLkKSJDo/uKUjwuLxzkpHEp+xvB8BYrHFMIefb28AQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.0.0
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.556.0
       tslib: 2.6.2
     dev: false
 
@@ -2127,6 +2568,19 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@smithy/signature-v4@2.3.0:
+    resolution: {integrity: sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-uri-escape': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
   /@smithy/smithy-client@2.3.1:
     resolution: {integrity: sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==}
     engines: {node: '>=14.0.0'}
@@ -2432,6 +2886,15 @@ packages:
     dependencies:
       '@smithy/abort-controller': 2.1.1
       '@smithy/types': 2.9.1
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/util-waiter@2.2.0:
+    resolution: {integrity: sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
@@ -4481,6 +4944,12 @@ packages:
       kind-of: 6.0.3
     dev: false
 
+  /mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+    dependencies:
+      obliterator: 1.6.1
+    dev: false
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -4547,6 +5016,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
+
+  /obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+    dev: false
 
   /on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}

--- a/handlers/src/bitbucket-metrics-register/bitbucket-metrics-register-handler.ts
+++ b/handlers/src/bitbucket-metrics-register/bitbucket-metrics-register-handler.ts
@@ -1,6 +1,8 @@
 import {Context} from 'aws-lambda';
 import {BitbucketWebhookRegistrar} from './bitbucket-webhook-registrar';
 import {logger} from '../logging-utils/logger';
+import {ThrottlingError} from '../metrics-utilities/throttling-error';
+import {EventBridgeUtils} from '../metrics-utilities/event-bridge-utils';
 
 interface CronEvent {
   version: string;
@@ -21,12 +23,30 @@ export async function handler(
   logger.debug(`Received Cron event: ${JSON.stringify(event, null, 2)}`);
   logger.debug(`Context: ${JSON.stringify(context, null, 2)}`);
 
-  // Register webhooks for Bitbucket repositories
-  const bitbucketWebhookRegistrar = await BitbucketWebhookRegistrar.create();
-  await bitbucketWebhookRegistrar.register('BitbucketMetricsCallback', [
-    'repo:commit_status_created',
-    'repo:commit_status_updated',
-  ]);
+  try {
+    // Register webhooks for Bitbucket repositories
+    const bitbucketWebhookRegistrar = await BitbucketWebhookRegistrar.create();
+    await bitbucketWebhookRegistrar.register('BitbucketMetricsCallback', [
+      'repo:commit_status_created',
+      'repo:commit_status_updated',
+    ]);
+  } catch (error) {
+    if (error instanceof ThrottlingError) {
+      // Handle ThrottlingError
+      console.error('ThrottlingError occurred:', error.message);
+      const currentDate = new Date();
+      currentDate.setMinutes(currentDate.getMinutes() + 61); // Start after an hour
+      const retryTime = currentDate;
+      await EventBridgeUtils.scheduleCron(
+        context.functionName,
+        context.invokedFunctionArn,
+        retryTime
+      );
+    } else {
+      // Rethrow the error
+      throw error;
+    }
+  }
 
   return {
     statusCode: 200,

--- a/handlers/src/bitbucket-metrics-register/bitbucket-metrics-register-handler.ts
+++ b/handlers/src/bitbucket-metrics-register/bitbucket-metrics-register-handler.ts
@@ -34,10 +34,10 @@ export async function handler(
     if (error instanceof ThrottlingError) {
       // Handle ThrottlingError
       console.error('ThrottlingError occurred:', error.message);
-      const currentDate = new Date();
-      currentDate.setMinutes(currentDate.getMinutes() + 61); // Start after an hour
-      const retryTime = currentDate;
+      const retryTime = new Date();
+      retryTime.setMinutes(retryTime.getMinutes() + 61); // Start after an hour
       await EventBridgeUtils.scheduleCron(
+        'BitBucketMetricsRegister',
         context.functionName,
         context.invokedFunctionArn,
         retryTime

--- a/handlers/src/bitbucket-metrics-register/bitbucket-services-helper.ts
+++ b/handlers/src/bitbucket-metrics-register/bitbucket-services-helper.ts
@@ -8,7 +8,7 @@ import {
 import {logger} from '../logging-utils/logger';
 import {TimedExponentialBackoff} from '../metrics-utilities/timed-exponential-backoff';
 
-const REMAINING_TIME_HEADER_NAME = 'retry-after';
+const REMAINING_TIME_HEADER_NAME = 'retry-after-time';
 
 export class BitbucketServicesHelper {
   public static async getRepositoriesPaginated(

--- a/handlers/src/bitbucket-metrics-register/bitbucket-services-helper.ts
+++ b/handlers/src/bitbucket-metrics-register/bitbucket-services-helper.ts
@@ -1,4 +1,3 @@
-import axios, {AxiosError, isAxiosError} from 'axios';
 import {Workspace} from './bitbucket-auth-helper';
 import {
   RepositoriesResponse,
@@ -7,13 +6,15 @@ import {
   WebhookResponse,
 } from './bitbucket-services-model';
 import {logger} from '../logging-utils/logger';
+import {TimedExponentialBackoff} from '../metrics-utilities/timed-exponential-backoff';
+
+const REMAINING_TIME_HEADER_NAME = 'retry-after';
 
 export class BitbucketServicesHelper {
   public static async getRepositoriesPaginated(
     workspace: Workspace,
     scmUrl?: string
   ): Promise<RepositoriesResponse | null> {
-    // TODO Need to handle 429 errors and do a backoff strategy
     let newScmUrl =
       scmUrl ??
       `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
@@ -23,12 +24,13 @@ export class BitbucketServicesHelper {
       newScmUrl += newScmUrl.includes('?') ? '&pagelen=100' : '?pagelen=100';
     }
 
-    const response = await axios.get(newScmUrl, {
-      headers: {
-        Authorization: `Bearer ${workspace.token}`,
-        Accept: 'application/json',
-      },
+    const response = await new TimedExponentialBackoff(
+      REMAINING_TIME_HEADER_NAME
+    ).makeRequest(newScmUrl, 'GET', {
+      Authorization: `Bearer ${workspace.token}`,
+      Accept: 'application/json',
     });
+
     logger.debug(
       `Repository Response: ${response.status} ${response.statusText}`
     );
@@ -64,42 +66,26 @@ export class BitbucketServicesHelper {
     repositorySlug: string,
     webhookRequest: WebhookRequest
   ): Promise<WebhookResponse | null> {
-    for (let i = 0; i < 3; i++) {
-      try {
-        const response = await axios.post(
-          `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
-            workspace.name
-          )}/${repositorySlug}/hooks`,
-          webhookRequest,
-          {
-            headers: {
-              Authorization: `Bearer ${workspace.token}`,
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        );
-        logger.debug(
-          `Webhook Creation Response: ${response.status} ${response.statusText}`
-        );
-        return response.data as WebhookResponse;
-      } catch (e) {
-        if (isAxiosError(e)) {
-          const ae = e as AxiosError;
-          if (ae.status === 429) {
-            logger.info(
-              'Rate limited while creating webhook, retrying in 10 seconds'
-            );
-            await new Promise(resolve => setTimeout(resolve, 10000));
-          } else {
-            throw e;
-          }
-        } else {
-          throw e;
-        }
-      }
-    }
-    throw new Error('Retries exhausted, failed to create webhook');
+    const newScmUrl = `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
+      workspace.name
+    )}/${repositorySlug}/hooks`;
+    const response = await new TimedExponentialBackoff(
+      REMAINING_TIME_HEADER_NAME
+    ).makeRequest(
+      newScmUrl,
+      'POST',
+      {
+        Authorization: `Bearer ${workspace.token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      webhookRequest
+    );
+
+    logger.debug(
+      `Webhook Creation Response: ${response.status} ${response.statusText}`
+    );
+    return response.data as WebhookResponse;
   }
 
   public static async updateRepositoryWebhook(
@@ -108,83 +94,47 @@ export class BitbucketServicesHelper {
     webhookUuid: string,
     webhookRequest: WebhookRequest
   ): Promise<WebhookResponse | null> {
-    // TODO Need to handle 429 errors and do a backoff strategy
-    for (let i = 0; i < 3; i++) {
-      try {
-        const response = await axios.put(
-          `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
-            workspace.name
-          )}/${repositorySlug}/hooks/${webhookUuid}`,
-          webhookRequest,
-          {
-            headers: {
-              Authorization: `Bearer ${workspace.token}`,
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
-          }
-        );
-        logger.debug(
-          `Webhook Update Response: ${response.status} ${response.statusText}`
-        );
-        return response.data as WebhookResponse;
-      } catch (e) {
-        if (isAxiosError(e)) {
-          const ae = e as AxiosError;
-          if (ae.status === 429) {
-            logger.info(
-              'Rate limited while updating webhook, retrying in 10 seconds'
-            );
-            await new Promise(resolve => setTimeout(resolve, 10000));
-          } else {
-            throw e;
-          }
-        } else {
-          throw e;
-        }
-      }
-    }
-    throw new Error('Retries exhausted, failed to update webhook');
+    const scmUrl = `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
+      workspace.name
+    )}/${repositorySlug}/hooks/${webhookUuid}`;
+
+    const response = await new TimedExponentialBackoff(
+      REMAINING_TIME_HEADER_NAME
+    ).makeRequest(
+      scmUrl,
+      'PUT',
+      {
+        Authorization: `Bearer ${workspace.token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      webhookRequest
+    );
+
+    logger.debug(
+      `Webhook Update Response: ${response.status} ${response.statusText}`
+    );
+    return response.data as WebhookResponse;
   }
 
   public static async getRepositoryWebhooks(
     workspace: Workspace,
     repositorySlug: string
   ): Promise<RepositoryWebhookResponse | null> {
-    // TODO Need to handle 429 errors and do a backoff strategy
-    for (let i = 0; i < 3; i++) {
-      try {
-        const response = await axios.get(
-          `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
-            workspace.name
-          )}/${repositorySlug}/hooks`,
-          {
-            headers: {
-              Authorization: `Bearer ${workspace.token}`,
-              Accept: 'application/json',
-            },
-          }
-        );
-        logger.debug(
-          `Repository Webhook Response: ${response.status} ${response.statusText}`
-        );
-        return response.data as RepositoryWebhookResponse;
-      } catch (e) {
-        if (isAxiosError(e)) {
-          const ae = e as AxiosError;
-          if (ae.status === 429) {
-            logger.info(
-              'Rate limited while getting webhooks, retrying in 10 seconds'
-            );
-            await new Promise(resolve => setTimeout(resolve, 10000));
-          } else {
-            throw e;
-          }
-        } else {
-          throw e;
-        }
-      }
-    }
-    throw new Error('Retries exhausted, failed to create webhook');
+    const scmUrl = `https://api.bitbucket.org/2.0/repositories/${encodeURIComponent(
+      workspace.name
+    )}/${repositorySlug}/hooks`;
+
+    const response = await new TimedExponentialBackoff(
+      REMAINING_TIME_HEADER_NAME
+    ).makeRequest(scmUrl, 'GET', {
+      Authorization: `Bearer ${workspace.token}`,
+      Accept: 'application/json',
+    });
+
+    logger.debug(
+      `Repository Webhook Response: ${response.status} ${response.statusText}`
+    );
+    return response.data as RepositoryWebhookResponse;
   }
 }

--- a/handlers/src/bitbucket-metrics-register/repository-tracker.ts
+++ b/handlers/src/bitbucket-metrics-register/repository-tracker.ts
@@ -32,7 +32,7 @@ export class RepositoryTrackerService {
     };
     try {
       await this.documentClient.send(new PutCommand(params));
-      logger.info(`Saved tracker for workspace: ${tracker.workspaceName}`);
+      logger.debug(`Saved tracker for workspace: ${tracker.workspaceName}`);
     } catch (error) {
       logger.error(error);
       throw new Error(
@@ -51,7 +51,7 @@ export class RepositoryTrackerService {
 
     try {
       const data = await this.documentClient.send(new GetCommand(params));
-      logger.info(`Got tracker for workspace: ${workspaceName}`);
+      logger.debug(`Got tracker for workspace: ${workspaceName}`);
       return data.Item as RepositoryTracker;
     } catch (error) {
       logger.error(`Could not get tracker for workspace: ${workspaceName}`, {

--- a/handlers/src/bitbucket-metrics-register/repository-tracker.ts
+++ b/handlers/src/bitbucket-metrics-register/repository-tracker.ts
@@ -1,0 +1,63 @@
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {DynamoDBClient} from '@aws-sdk/client-dynamodb';
+import {logger} from '../logging-utils/logger';
+
+export interface RepositoryTracker {
+  readonly workspaceName: string;
+  readonly nextUrl: string;
+}
+export class RepositoryTrackerService {
+  private readonly documentClient: DynamoDBDocumentClient;
+  readonly repositoryTrackerTableName: string;
+
+  constructor() {
+    this.documentClient = DynamoDBDocumentClient.from(
+      new DynamoDBClient({region: process.env.AWS_REGION!})
+    );
+    this.repositoryTrackerTableName =
+      process.env.REPOSITORY_TRACKER_TABLE_NAME!;
+  }
+
+  public async saveTracker(tracker: RepositoryTracker): Promise<void> {
+    const params = {
+      TableName: this.repositoryTrackerTableName,
+      Item: {
+        id: tracker.workspaceName,
+        ...tracker,
+      },
+    };
+    try {
+      await this.documentClient.send(new PutCommand(params));
+      logger.info(`Saved tracker for workspace: ${tracker.workspaceName}`);
+    } catch (error) {
+      logger.error(error);
+      throw new Error(
+        `Could not save tracker for workspace: ${tracker.workspaceName}`
+      );
+    }
+  }
+
+  public async getTracker(
+    workspaceName: string
+  ): Promise<RepositoryTracker | undefined> {
+    const params = {
+      TableName: this.repositoryTrackerTableName,
+      Key: {id: workspaceName},
+    };
+
+    try {
+      const data = await this.documentClient.send(new GetCommand(params));
+      logger.info(`Got tracker for workspace: ${workspaceName}`);
+      return data.Item as RepositoryTracker;
+    } catch (error) {
+      logger.error(`Could not get tracker for workspace: ${workspaceName}`, {
+        error,
+      });
+      return undefined;
+    }
+  }
+}

--- a/handlers/src/metrics-utilities/event-bridge-utils.ts
+++ b/handlers/src/metrics-utilities/event-bridge-utils.ts
@@ -1,0 +1,41 @@
+import {logger} from '../logging-utils/logger';
+import {
+  EventBridgeClient,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from '@aws-sdk/client-eventbridge';
+
+const eventBridge = new EventBridgeClient({region: process.env.AWS_REGION});
+export class EventBridgeUtils {
+  public static async scheduleCron(
+    lambdaName: string,
+    lambdaArn: string,
+    retryTime: Date
+  ) {
+    logger.info(
+      `Scheduling cron job: ${lambdaName} at ${retryTime} and arn: ${lambdaArn}`
+    );
+
+    const ruleName = `${lambdaName}-retryRule-${retryTime}`;
+    await eventBridge.send(
+      new PutRuleCommand({
+        Name: ruleName,
+        ScheduleExpression: `cron(${retryTime.getMinutes()} ${retryTime.getHours()} ${retryTime.getDate()} ${
+          retryTime.getMonth() + 1
+        } ? ${retryTime.getFullYear()})`,
+      })
+    );
+
+    await eventBridge.send(
+      new PutTargetsCommand({
+        Rule: ruleName,
+        Targets: [
+          {
+            Id: 'default',
+            Arn: lambdaArn,
+          },
+        ],
+      })
+    );
+  }
+}

--- a/handlers/src/metrics-utilities/event-bridge-utils.ts
+++ b/handlers/src/metrics-utilities/event-bridge-utils.ts
@@ -32,7 +32,7 @@ export class EventBridgeUtils {
         Rule: ruleName,
         Targets: [
           {
-            Id: 'default',
+            Id: 'retryTarget',
             Arn: lambdaArn,
           },
         ],

--- a/handlers/src/metrics-utilities/event-bridge-utils.ts
+++ b/handlers/src/metrics-utilities/event-bridge-utils.ts
@@ -8,6 +8,7 @@ import {
 const eventBridge = new EventBridgeClient({region: process.env.AWS_REGION});
 export class EventBridgeUtils {
   public static async scheduleCron(
+    cronPrefix: string,
     lambdaName: string,
     lambdaArn: string,
     retryTime: Date
@@ -16,7 +17,7 @@ export class EventBridgeUtils {
       `Scheduling cron job: ${lambdaName} at ${retryTime} and arn: ${lambdaArn}`
     );
 
-    const ruleName = `${lambdaName}-retryRule-${retryTime}`;
+    const ruleName = `${cronPrefix}-Retry`;
     await eventBridge.send(
       new PutRuleCommand({
         Name: ruleName,

--- a/handlers/src/metrics-utilities/metrics-utilities.ts
+++ b/handlers/src/metrics-utilities/metrics-utilities.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import {logger} from '../logging-utils/logger';
+import {AxiosError, AxiosRequestHeaders, AxiosResponse} from 'axios';
 
 export class MetricsUtilities {
   public static createRepositorySlug(repositoryName: string): string {
@@ -19,5 +20,27 @@ export class MetricsUtilities {
     } catch (error) {
       logger.error('Error reading file from disk', {error});
     }
+  }
+
+  public static throwThrottlingError() {
+    const error = new Error('Rate limit exceeded') as AxiosError;
+    error.name = 'AxiosError';
+    error.message = 'Max connections reached';
+    error.code = '429';
+    error.request = {};
+    error.response = {
+      status: 429,
+      statusText: 'Max connections reached',
+      headers: {},
+      config: {
+        headers: {
+          Authorization: 'Bearer',
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        } as AxiosRequestHeaders,
+      },
+    } as AxiosResponse;
+
+    throw error;
   }
 }

--- a/handlers/src/metrics-utilities/throttling-error.ts
+++ b/handlers/src/metrics-utilities/throttling-error.ts
@@ -1,0 +1,8 @@
+export class ThrottlingError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'ThrottlingError';
+    // (see note below)
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/handlers/src/metrics-utilities/timed-exponential-backoff.ts
+++ b/handlers/src/metrics-utilities/timed-exponential-backoff.ts
@@ -20,7 +20,7 @@ export class TimedExponentialBackoff {
   private nextDelayWithJitter: number;
 
   constructor(remainingTimeHeader: string) {
-    this.initialDelay = 60_000; //ms
+    this.initialDelay = 60000; //ms
     this.maxDelay = 180_0000; // Maximum delay between retries
     this.multiplier = 2; // Exponential backoff multiplier
     this.jitter = Math.floor(Math.random() * 10);

--- a/handlers/src/metrics-utilities/timed-exponential-backoff.ts
+++ b/handlers/src/metrics-utilities/timed-exponential-backoff.ts
@@ -1,0 +1,104 @@
+/** @internal */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import axios, {
+  AxiosError,
+  AxiosRequestConfig,
+  AxiosResponse,
+  Method,
+} from 'axios';
+import {logger} from '../logging-utils/logger';
+
+export class TimedExponentialBackoff {
+  private readonly initialDelay: number;
+  private readonly maxDelay: number;
+  private readonly multiplier: number;
+  private readonly jitter: number;
+  private readonly remainingTimeHeader: string;
+
+  private nextDelay: number;
+  private nextDelayWithJitter: number;
+
+  constructor(remainingTimeHeader: string) {
+    this.initialDelay = 300_000; //ms
+    this.maxDelay = 300_0000; // Maximum delay between retries
+    this.multiplier = 5; // Exponential backoff multiplier
+    this.jitter = Math.floor(Math.random() * 10);
+
+    this.nextDelay = this.initialDelay;
+    this.nextDelayWithJitter = this.initialDelay;
+    this.remainingTimeHeader = remainingTimeHeader;
+  }
+
+  reset() {
+    this.nextDelay = this.initialDelay;
+    this.nextDelayWithJitter = this.initialDelay;
+  }
+
+  delay() {
+    const delay = this.nextDelayWithJitter;
+    this.nextDelay = Math.min(this.nextDelay * this.multiplier, this.maxDelay);
+    this.nextDelayWithJitter =
+      this.nextDelay + Math.floor(Math.random() * this.jitter);
+    return delay;
+  }
+
+  public async makeRequest(
+    url: string,
+    method: Method,
+    headers?: {[key: string]: string},
+    data?: any,
+    retries = 3
+  ): Promise<AxiosResponse<any>> {
+    const config: AxiosRequestConfig = {
+      method: method,
+      url: url,
+      auth: {
+        username: 'username', // Replace with actual credentials or use environment variables
+        password: 'app_password',
+      },
+      headers,
+      data: data,
+    };
+
+    try {
+      return await axios(config);
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      if (
+        axiosError.response &&
+        axiosError.response.status === 429 &&
+        retries > 0
+      ) {
+        // Handle rate limit exceeded, with retry-after support
+        let retryAfter = parseInt(
+          axiosError.response.headers[this.remainingTimeHeader],
+          10
+        );
+
+        if (retryAfter) {
+          retryAfter = retryAfter * 1000;
+          logger.info(
+            `API Timed Back off:: Rate limit exceeded. Retrying after ${
+              retryAfter / 1000
+            } seconds.`
+          );
+        } else {
+          retryAfter = this.delay();
+          logger.info(
+            `Exponential Back off:: Rate limit exceeded. Retrying after ${
+              retryAfter / 1000
+            } seconds.`
+          );
+        }
+
+        logger.info(
+          `Rate limit exceeded. Retrying after ${retryAfter / 1000} seconds.`
+        );
+        await new Promise(resolve => setTimeout(resolve, retryAfter));
+        return this.makeRequest(url, method, data, retries - 1); // Retry the request
+      } else {
+        throw axiosError;
+      }
+    }
+  }
+}

--- a/handlers/src/metrics-utilities/timed-exponential-backoff.ts
+++ b/handlers/src/metrics-utilities/timed-exponential-backoff.ts
@@ -20,8 +20,8 @@ export class TimedExponentialBackoff {
   private nextDelayWithJitter: number;
 
   constructor(remainingTimeHeader: string) {
-    this.initialDelay = 150_000; //ms
-    this.maxDelay = 600_0000; // Maximum delay between retries
+    this.initialDelay = 60_000; //ms
+    this.maxDelay = 180_0000; // Maximum delay between retries
     this.multiplier = 2; // Exponential backoff multiplier
     this.jitter = Math.floor(Math.random() * 10);
 
@@ -46,10 +46,11 @@ export class TimedExponentialBackoff {
   public async makeRequest(
     url: string,
     method: Method,
-    headers?: {[key: string]: string},
+    headers: {[key: string]: string},
     data?: any,
     retries = 3
   ): Promise<AxiosResponse<any>> {
+    logger.debug(`Retries left: ${retries} `);
     const config: AxiosRequestConfig = {
       method: method,
       url: url,
@@ -89,7 +90,7 @@ export class TimedExponentialBackoff {
             `Rate limit exceeded. Retrying after ${retryAfter / 1000} seconds.`
           );
           await new Promise(resolve => setTimeout(resolve, retryAfter));
-          return this.makeRequest(url, method, data, retries - 1); // Retry the request
+          return this.makeRequest(url, method, headers, data, retries - 1); // Retry the request
         } else {
           throw new ThrottlingError('Rate limit exceeded');
         }


### PR DESCRIPTION
**What?**

- Add timed and exponential backoff strategies when calling bitbucket
-  Add the ability to track the next page of list repositories per workspace in dynamo db to enable next job to resume from where it left (only one entry is maintained in the db)
-  Add the ability to allow the lambda to reschedule when a 429 is received

**Why?**
-  429 errors resulted in the lambdas failing to register hooks in YL
-  The retries were always starting from the first repository results page instead of the last page accessed
-  In case of too many repositories, the lambda will not register all of them in one go thus the need to reschedule when the backoff strategy fails

**Testing**
- Tested manually on the truemark repo and the registrations succeeded
-  More unit test and code coverage to follow

**Documentation**
- To be updated in the next PR (Only for docs and unit tests)